### PR TITLE
Add demo of job scheduling using quartz

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'org.springframework.boot' version '2.2.2.RELEASE'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
     id 'java'
-
     id "io.freefair.lombok" version "5.1.0"
 }
 
@@ -12,9 +11,13 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation("org.springframework.boot:spring-boot-starter-quartz")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation('org.flywaydb:flyway-core')
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    runtimeOnly('org.postgresql:postgresql')
 }
 
 test {

--- a/src/main/java/com/wilkins/showcase/controllers/GreetingController.java
+++ b/src/main/java/com/wilkins/showcase/controllers/GreetingController.java
@@ -1,23 +1,73 @@
 package com.wilkins.showcase.controllers;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.quartz.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Date;
+import java.util.UUID;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.*;
 import static org.springframework.util.StringUtils.isEmpty;
 
 @Slf4j
 @RestController
+@RequestMapping(path = "/greeting", produces = APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
 public class GreetingController {
 
-    @GetMapping("/greeting")
+    private static final String JOB_GROUP = "greeting-jobs";
+    private final Scheduler scheduler;
+
+    @GetMapping
     public Greeting getGreeting(@RequestParam(name = "salutation", required = false) String salutationParam,
-                               @RequestParam(name = "name", required = false) String nameParam) {
+                                @RequestParam(name = "name", required = false) String nameParam) {
 
         log.info("A greeting was requested");
 
-        Greeting greeting = Greeting.of("hello", "world");
+        var greeting = aGreeting(salutationParam, nameParam);
+
+        log.info("Greeting returned: {}", greeting);
+
+        return greeting;
+    }
+
+    @PostMapping
+    public String postGreeting(@RequestParam(name = "salutation", required = false) String salutationParam,
+                         @RequestParam(name = "name", required = false) String nameParam) throws SchedulerException {
+        var jobDataMap = new JobDataMap();
+        jobDataMap.put("salutation", aGreeting(salutationParam, nameParam).getSalutation());
+        jobDataMap.put("name", aGreeting(salutationParam, nameParam).getName());
+        var id = UUID.randomUUID().toString();
+        var jobDetail = JobBuilder.newJob()
+                .ofType(GreetingJob.class)
+                .withIdentity(id, JOB_GROUP)
+                .withDescription("Send Greeting Job")
+                .usingJobData(jobDataMap)
+                .storeDurably()
+                .build();
+        var trigger = TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), "greeting-triggers")
+                .withDescription("Send Greeting Trigger")
+                .startAt(new Date())
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInSeconds(10).repeatForever())
+                .build();
+        scheduler.scheduleJob(jobDetail, trigger);
+        return id;
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteGreeting(@PathVariable String id) throws SchedulerException {
+        log.info("deleting job: {}", id);
+        return scheduler.deleteJob(new JobKey(id, JOB_GROUP)) ? noContent().build() : notFound().build();
+    }
+
+    private Greeting aGreeting(String salutationParam, String nameParam) {
+        var greeting = Greeting.of("hello", "world");
 
         if (!isEmpty(salutationParam)) {
             greeting = greeting.withSalutation(salutationParam);
@@ -25,9 +75,6 @@ public class GreetingController {
         if (!isEmpty(nameParam)) {
             greeting = greeting.withName(nameParam);
         }
-
-        log.info("Greeting returned: {}", greeting);
-
         return greeting;
     }
 }

--- a/src/main/java/com/wilkins/showcase/controllers/GreetingJob.java
+++ b/src/main/java/com/wilkins/showcase/controllers/GreetingJob.java
@@ -1,0 +1,18 @@
+package com.wilkins.showcase.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+@Slf4j
+public class GreetingJob implements Job {
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        JobDataMap jobDataMap = context.getMergedJobDataMap();
+        log.info("{}, {}, {}", context.getJobDetail().getKey().getName(),
+                jobDataMap.getString("salutation"),
+                jobDataMap.getString("name"));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,16 @@
+spring:
+  quartz:
+    job-store-type: jdbc
+    properties.org.quartz.threadPool.threadCount: 5
+    jdbc:
+      initialize-schema: embedded
+    properties:
+      org:
+        quartz:
+          jobStore:
+            driverDelegateClass: "org.quartz.impl.jdbcjobstore.PostgreSQLDelegate"
+    wait-for-jobs-to-complete-on-shutdown: true
+  datasource:
+    url: "jdbc:postgresql://localhost:5432/postgres?currentSchema=showcase"
+    username: "postgres"
+    password: "Passw0rd"


### PR DESCRIPTION
The GreetingController is extended, so it now allows a POST which schedules a job to
run at a set frequency. The job just logs the Greeting to the console

Quartz is a framework which allows Jobs to be scheduled to run asynchronously, at a fixed
frequency or point in time. This is useful if youo want to allow the API user to
schedule a task to be performed at a set point in the future

The job schedule is persisted in a postgres database, so they will live beyond the lifespan
of an application run. I.e. the application can be restarted, and the running jobs will
restart.

Jira: n/a