### PR TITLE
Add Togglz feature flag framework and spring security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 /.project
 /bin/
 /.settings/
+/.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.1'
+    id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
 }
@@ -11,9 +11,20 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    togglz_version = "4.0.1"
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+    implementation("org.togglz:togglz-spring-boot-starter:${togglz_version}")
+    implementation("org.togglz:togglz-console:${togglz_version}")
+//    implementation("org.togglz:togglz-security-spring-boot-starter:${togglz_version}")
 }
 
 test {

--- a/src/main/java/com/wilkins/showcase/TogglzConfiguration.java
+++ b/src/main/java/com/wilkins/showcase/TogglzConfiguration.java
@@ -1,0 +1,36 @@
+package com.wilkins.showcase;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.TogglzConfig;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.user.SimpleFeatureUser;
+import org.togglz.core.user.UserProvider;
+import org.togglz.core.util.NamedFeature;
+
+@Configuration
+public class TogglzConfiguration implements TogglzConfig {
+
+    private final StateRepository stateRepository;
+
+    public TogglzConfiguration(StateRepository stateRepository) {
+        this.stateRepository = stateRepository;
+    }
+
+    @Override
+    public Class<? extends Feature> getFeatureClass() {
+        return NamedFeature.class;
+    }
+
+    @Override
+    public StateRepository getStateRepository() {
+        return stateRepository;
+    }
+
+    @Override
+    @Bean
+    public UserProvider getUserProvider() {
+        return () -> new SimpleFeatureUser("admin", true);
+    }
+}

--- a/src/main/java/com/wilkins/showcase/WebSecurityConfig.java
+++ b/src/main/java/com/wilkins/showcase/WebSecurityConfig.java
@@ -1,0 +1,36 @@
+package com.wilkins.showcase;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractAuthenticationFilterConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/actuator",
+                                "/actuator/*",
+                                "/togglz-console",
+                                "/togglz-console/**",
+                                "/togglz*",
+                                "/togglz**"
+                        )
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractAuthenticationFilterConfigurer::permitAll)
+                .logout(LogoutConfigurer::permitAll)
+                .build();
+    }
+}

--- a/src/main/java/com/wilkins/showcase/controller/GreetingController.java
+++ b/src/main/java/com/wilkins/showcase/controller/GreetingController.java
@@ -6,12 +6,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.togglz.core.Feature;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.util.NamedFeature;
 
 @RestController
 @RequestMapping("/greetings")
 public class GreetingController {
 
     private static final Logger log = LoggerFactory.getLogger(GreetingController.class);
+    private final FeatureManager featureManager;
+
+    private static final Feature cheeky = new NamedFeature("CHEEKY_GREETING");
+
+    public GreetingController(FeatureManager featureManager) {
+        this.featureManager = featureManager;
+    }
 
     @GetMapping
     public JsonGreeting getGreeting(@RequestParam(name = "salutation", required = false, defaultValue = "hello") String salutationParam,
@@ -20,6 +30,9 @@ public class GreetingController {
         log.info("A greeting was requested");
 
         var greeting = JsonGreeting.of(salutationParam, nameParam);
+        if (featureManager.isActive(cheeky)) {
+            greeting = JsonGreeting.of("Get out of here!", nameParam);
+        }
 
         log.info("Greeting returned: {}", greeting);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+togglz:
+  enabled:
+    true
+  features:
+    CHEEKY_GREETING:
+      enabled: false
+  console:
+    secured: false
+    use-management-port: true
+  endpoint:
+    enabled: true
+    id: togglz
+management:
+  endpoints:
+    web:
+      exposure:
+        include: 'togglz, health'
+  server:
+    port: 8081
+
+spring:
+  main:
+    banner-mode: off


### PR DESCRIPTION
Add a basic demo of the togglz framework which can be used to enable/disable certain features The togglz console can be accessed at localhost:8080/togglz-console. Actuator endpoints are also available.

Spring security is added to secure the features while allowing the api to be left open