### PR TITLE
Add endpoint to stream data read from database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
+    id("io.freefair.lombok") version "8.10.2"
 }
 
 targetCompatibility = '22'
@@ -14,6 +15,10 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+    implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation('org.flywaydb:flyway-core')
+    runtimeOnly('com.h2database:h2')
 }
 
 test {

--- a/src/main/java/com/wilkins/showcase/Book.java
+++ b/src/main/java/com/wilkins/showcase/Book.java
@@ -1,0 +1,4 @@
+package com.wilkins.showcase;
+
+public record Book(String id, String name, String author) {
+}

--- a/src/main/java/com/wilkins/showcase/controller/BookController.java
+++ b/src/main/java/com/wilkins/showcase/controller/BookController.java
@@ -1,0 +1,31 @@
+package com.wilkins.showcase.controller;
+
+import com.wilkins.showcase.service.BookService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.http11.Constants;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequestMapping("/books")
+@Slf4j
+@RequiredArgsConstructor
+public class BookController {
+
+    private final BookService bookService;
+
+    @GetMapping
+    ResponseEntity<StreamingResponseBody> streamBooks() {
+        log.info("streaming books");
+        return ok()
+                .header(HttpHeaders.CONTENT_ENCODING, Constants.CHUNKED)
+                .body(bookService::streamBooks);
+    }
+}

--- a/src/main/java/com/wilkins/showcase/controller/JsonBook.java
+++ b/src/main/java/com/wilkins/showcase/controller/JsonBook.java
@@ -1,0 +1,9 @@
+package com.wilkins.showcase.controller;
+
+import com.wilkins.showcase.Book;
+
+public record JsonBook(String id, String name, String author) {
+    public static JsonBook from(Book book) {
+        return new JsonBook(book.id(), book.name(), book.author());
+    }
+}

--- a/src/main/java/com/wilkins/showcase/service/BookRepository.java
+++ b/src/main/java/com/wilkins/showcase/service/BookRepository.java
@@ -1,0 +1,9 @@
+package com.wilkins.showcase.service;
+
+import com.wilkins.showcase.Book;
+
+import java.util.stream.Stream;
+
+public interface BookRepository {
+    Stream<Book> findAll();
+}

--- a/src/main/java/com/wilkins/showcase/service/BookService.java
+++ b/src/main/java/com/wilkins/showcase/service/BookService.java
@@ -1,0 +1,7 @@
+package com.wilkins.showcase.service;
+
+import java.io.OutputStream;
+
+public interface BookService {
+    void streamBooks(OutputStream outputStream);
+}

--- a/src/main/java/com/wilkins/showcase/service/DefaultBookService.java
+++ b/src/main/java/com/wilkins/showcase/service/DefaultBookService.java
@@ -1,0 +1,37 @@
+package com.wilkins.showcase.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wilkins.showcase.controller.JsonBook;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class DefaultBookService implements BookService {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final BookRepository bookRepository;
+
+    @Override
+    public void streamBooks(OutputStream outputStream) {
+        try (var books = bookRepository.findAll()) {
+            books
+                    .map(JsonBook::from)
+                    .forEach(book -> {
+                        try {
+                            log.info("getting book {}", book);
+                            Thread.sleep(2000);
+                            log.info("writing book {}", book.name());
+                            outputStream.write(objectMapper.writeValueAsBytes(book));
+                            outputStream.flush();
+                        } catch (IOException | InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+    }
+}

--- a/src/main/java/com/wilkins/showcase/service/JooqBookRepository.java
+++ b/src/main/java/com/wilkins/showcase/service/JooqBookRepository.java
@@ -1,0 +1,40 @@
+package com.wilkins.showcase.service;
+
+import com.wilkins.showcase.Book;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.jooq.impl.DSL.field;
+
+@Service
+public class JooqBookRepository implements BookRepository {
+
+    private final DSLContext dsl;
+
+    public JooqBookRepository(DataSource dataSource) throws SQLException {
+        this.dsl = DSL.using(dataSource.getConnection());
+    }
+
+    @Override
+    public Stream<Book> findAll() {
+        return dsl.select(bookFields)
+                .from(bookTable)
+                .fetchStreamInto(Book.class);
+    }
+
+    private static final Table<Record> bookTable = DSL.table("book");
+    private static final Field<String> externalId = field("book.external_id", String.class);
+    private static final Field<String> title = field("book.title", String.class);
+    private static final Field<String> author = field("book.author", String.class);
+    private static final List<Field<String>> fields = List.of(externalId, title, author);
+    private static final Field[] bookFields = fields.toArray(new Field[0]);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,12 @@ server:
   port: 8080
   servlet:
     application-display-name: showcase
+
+spring:
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:showcase
+    username: showcase
+    password: Passw0rd!

--- a/src/main/resources/db/migration/V0__create_book.sql
+++ b/src/main/resources/db/migration/V0__create_book.sql
@@ -1,0 +1,28 @@
+create table book
+(
+    id          bigint       not null auto_increment,
+    external_id varchar(120) not null,
+    title       varchar(120),
+    author      varchar(120),
+    constraint book_pk primary key (id),
+    constraint book_external_id unique (external_id)
+);
+
+insert into book(external_id, title, author)
+values ('hobbit_01', 'The Hobbit', 'JRR Tolkien');
+insert into book(external_id, title, author)
+values ('lord_01', 'Fellowship of the Ring', 'JRR Tolkien');
+insert into book(external_id, title, author)
+values ('lord_02', 'The Two Towers', 'JRR Tolkien');
+insert into book(external_id, title, author)
+values ('lord_03', 'Return of the King', 'JRR Tolkien');
+insert into book(external_id, title, author)
+values ('madding_01', 'Far from the Madding Crowd', 'Thomas Hardy');
+insert into book(external_id, title, author)
+values ('merchant_01', 'The Merchant of Venice', 'William Shakespear');
+insert into book(external_id, title, author)
+values ('hamlet_01', 'Hamlet', 'William Shakespear');
+insert into book(external_id, title, author)
+values ('romeo_01', 'Romeo and Juliet', 'William Shakespear');
+insert into book(external_id, title, author)
+values ('macbeth_01', 'Macbeth', 'William Shakespear');


### PR DESCRIPTION
Add a streaming http endpoint returning Book objects. Books are streamed from the database using the JOOQ framework. The books read from the database are then streamed to an OutputStream. Where there are a large number of documents needing to be returned, or processing each document takes time, this allows the service to return documents to the client as then are available, rather than having to wait for them all to be returned at the end

the endpoint can be tested with curl:

`curl --no-buffer localhost:8080/books`

where books can be seen streamed individually to the console.